### PR TITLE
Switch to using global context: partial fix for ...

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   "dependencies": {
     "colors": ">=0.6 <1",
     "optimist": ">=0.3.5 <1",
-    "underscore": ">=1.4 <2"
+    "underscore": ">=1.4 <2",
+    "semver": "~2.1.0"
   },
   "peerDependencies": {
     "coffee-script": ">=1.6.2 <2"

--- a/src/languages/coffee.coffee
+++ b/src/languages/coffee.coffee
@@ -6,6 +6,7 @@ require 'colors'
 coffee = require 'coffee-script'
 log = require '../log'
 path = require 'path'
+semver = require 'semver'
 
 exports.setup = (context) ->
     {nesh} = context
@@ -21,5 +22,10 @@ exports.setup = (context) ->
     nesh.defaults.welcome = "CoffeeScript #{coffee.VERSION} on Node #{process.version}\nType " + '.help'.cyan + ' for more information'
     # Set the CoffeeScript prompt
     nesh.defaults.prompt = 'coffee> '
+    # !! While we *want* to use the global context, a bug in CoffeeScript as of 1.6.3 
+    # !! - see https://github.com/jashkenas/coffee-script/pull/3113 - currently prevents that.
+    # !! Once the bug has been fixed, replace 'no' with the expression in the inline comment, 
+    # !! with the fixed-in version number filled in for '?'
+    nesh.defaults.useGlobal = no # semver.satisfies(coffee.VERSION, ">= ?")
     # Save history in ~/.coffee_history
     nesh.defaults.historyFile = path.join(process.env.HOME, '.coffee_history')

--- a/src/nesh.coffee
+++ b/src/nesh.coffee
@@ -77,6 +77,7 @@ nesh.version = neshInfo.version
 
 # An object used to populate default values for the repl
 nesh.defaults =
+    useGlobal: yes  # Using the global context allows packages such as 'colors' to modify built-in prototypes.
     prompt: 'nesh> '
 
 # Languages

--- a/src/plugins/eval.coffee
+++ b/src/plugins/eval.coffee
@@ -13,4 +13,7 @@ exports.postStart = (context) ->
     {repl} = context
     if repl.opts.evalData
         log.debug 'Evaluating code in the REPL'
-        vm.runInContext repl.opts.evalData, repl.context
+        if global is repl.context
+        	vm.runInThisContext repl.opts.evalData
+        else
+        	vm.runInContext repl.opts.evalData, repl.context


### PR DESCRIPTION
... issue https://github.com/danielgtaylor/nesh/issues/4

Nesh now defaults to using the global context, which enables packages
that modify built-in prototypes to function correctly.

Takes effect for the _JavaScript_ REPL, but
the default for the _CoffeeScript_ REPL is of necessity kept NON-global
until a bug in CoffeeScript (as of 1.6.3) is resolved - see
https://github.com/jashkenas/coffee-script/pull/3113

Note:
- I've made no attempt to indicate to the user that - for now - the global context is NOT active when running the _CoffeeScript_ REPL - wonder if it makes sense to issue a warning on startup.
- The `semver` dependency added is not actively used yet, but will come in handy for version comparison once the specific CoffeeScript version with the required fix is known.  
  Edit: Alternatives are to (a) remove the dependency for now or (b) to obviate the need for a version check altogether by eventually updating the peer dependency on CoffeeScript to require at least the version with the pending fix.
