### PR TITLE
Switching from underscore to lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,11 +42,10 @@
   "license": "MIT",
   "dependencies": {
     "colors": ">=0.6 <1",
-    "optimist": ">=0.3.5 <1",
-    "underscore": ">=1.4 <2",
-    "semver": "~2.2.1",
     "intdoc": "~0.1.2",
-    "lodash-node": "~2.4.1"
+    "lodash-node": "^2.4.1",
+    "optimist": ">=0.3.5 <1",
+    "semver": "~2.2.1"
   },
   "peerDependencies": {
     "coffee-script": ">=1.6.2 <2"

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -2,7 +2,7 @@
 The nesh command, which parses options and then drops the user
 into an interactive session.
 ###
-_ = require 'underscore'
+_ = require 'lodash-node'
 {exec} = require 'child_process'
 fs = require 'fs'
 nesh = require './nesh'

--- a/src/plugins/autoload.coffee
+++ b/src/plugins/autoload.coffee
@@ -16,7 +16,7 @@ Config options:
 }
 
 ###
-_ = require 'underscore'
+_ = require 'lodash-node'
 fs = require 'fs'
 nesh = require '../nesh'
 path = require 'path'

--- a/src/plugins/builtins.coffee
+++ b/src/plugins/builtins.coffee
@@ -2,7 +2,7 @@
 Builtin Utilities Plugin
 ###
 
-_ = require 'underscore'
+_ = require 'lodash-node'
 crypto = require 'crypto'
 querystring = require 'querystring'
 


### PR DESCRIPTION
Lodash is a drop-in replacement for underscore that is faster and
more actively maintained. Since it is drop-in compatible, switching to it
is trivial. The `require` statements are just changed from lines like
`_ = require 'underscore'` to `_ = require 'lodash-node'`

Tested plan: Ran `cake test` and manually tested a few things

See:
http://joefleming.net/posts/use-lodash-instead-of-underscore/
http://stackoverflow.com/questions/13789618/differences-between-lodash-and-u
